### PR TITLE
feat: KubeObject can choose fieldpath with "K=V" selector

### DIFF
--- a/go/fn/errors.go
+++ b/go/fn/errors.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"log"
 	"strings"
+
+	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn/internal"
 )
 
 // ErrMissingFnConfig raises error if a required functionConfig is missing.
@@ -40,9 +42,12 @@ func (e *ErrOpOrDie) Error() string {
 
 func handleOptOrDieErr() {
 	if v := recover(); v != nil {
-		if e, ok := v.(ErrOpOrDie); ok {
-			log.Fatalf(e.Error())
-		} else {
+		switch v.(type) {
+		case ErrOpOrDie:
+			log.Fatalf(v.(*ErrOpOrDie).Error())
+		case internal.ErrEqualSelector:
+			log.Fatalf(v.(*internal.ErrEqualSelector).Error())
+		default:
 			panic(v)
 		}
 	}

--- a/go/fn/examples/example_read_field_test.go
+++ b/go/fn/examples/example_read_field_test.go
@@ -30,10 +30,13 @@ func Example_aReadField() {
 
 func readField(rl *fn.ResourceList) error {
 	for _, obj := range rl.Items {
-		if obj.GetAPIVersion() == "apps/v1" && obj.GetKind() == "Deployment" {
+		switch{
+		case obj.IsGVK("apps/v1", "Deployment"):
 			var replicas int
 			obj.GetOrDie(&replicas, "spec", "replicas")
-			fn.Logf("replicas is %v\n", replicas)
+		case obj.IsGVK("rbac.authorization.k8s.io/v1", "ClusterRoleBinding"):
+			var namespace string
+			obj.GetOrDie(&namespace, "subjects", "kind=ServiceAccount", "namespace")
 		}
 	}
 	return nil

--- a/go/fn/examples/example_set_field_test.go
+++ b/go/fn/examples/example_set_field_test.go
@@ -30,9 +30,13 @@ func Example_cSetField() {
 
 func setField(rl *fn.ResourceList) error {
 	for _, obj := range rl.Items {
-		if obj.GetAPIVersion() == "apps/v1" && obj.GetKind() == "Deployment" {
+		switch{
+		case obj.IsGVK("apps/v1", "Deployment"):
 			replicas := 10
 			obj.SetOrDie(&replicas, "spec", "replicas")
+		case obj.IsGVK("rbac.authorization.k8s.io/v1", "ClusterRoleBinding"):
+			namespace := "test"
+			obj.SetOrDie(&namespace, "subjects", "kind=ServiceAccount", "namespace")
 		}
 	}
 	return nil

--- a/go/fn/internal/errors.go
+++ b/go/fn/internal/errors.go
@@ -1,0 +1,16 @@
+package internal
+
+import (
+	"fmt"
+)
+
+// ErrOpOrDie raises if the KubeObject operation panics.
+type ErrEqualSelector struct {
+	field string
+	expected string
+	actual string
+}
+
+func (e *ErrEqualSelector) Error() string {
+	return fmt.Sprintf("invalid selector syntax: expect %v, got %v ", e.expected, e.actual)
+}

--- a/go/fn/internal/selector.go
+++ b/go/fn/internal/selector.go
@@ -1,0 +1,37 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package internal
+
+import (
+	"strings"
+)
+
+const equalDelimiter = "="
+
+func IsEqualSelector(field string) bool{
+	if strings.Contains(field, equalDelimiter) {
+		return true
+	}
+	// TODO: extend and support multi "equal" syntax. e.g. `kind=Project,name=kit`
+	return false
+}
+
+func GetEqualSelector(field string) (string, string){
+	segments := strings.Split(field, equalDelimiter)
+	if len(segments) != 2 {
+		panic(ErrEqualSelector{expected: "YOUR_KEY=YOUR_VALUE", actual: field})
+	}
+	return segments[0], segments[1]
+}
+

--- a/go/fn/internal/slice.go
+++ b/go/fn/internal/slice.go
@@ -49,3 +49,24 @@ func (v *sliceVariant) Objects() ([]*MapVariant, error) {
 func (v *sliceVariant) Add(node variant) {
 	v.node.Content = append(v.node.Content, node.Node())
 }
+
+func (o *sliceVariant) GetSliceElementBySelector(field string) (*MapVariant, error) {
+	key, expected := GetEqualSelector(field)
+	elements, err := o.Objects()
+	if err != nil {
+		return nil, err
+	}
+	for _, mapElement := range elements {
+		actual, found, err := mapElement.GetNestedString(key)
+		if !found {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		if actual == expected {
+			return mapElement, nil
+		}
+	}
+	return nil, nil
+}


### PR DESCRIPTION
Current `GetXXX(fields []string)` and `SetXXX(fields []string)` requires the`internal.variant`of each `fields` to be a MapVariant except the last field `fields[len(fields)-1`]. This PR allows the intermediate variant to be a sliceVariant and select the element from the  sliceVariant by a `KEY=VALUE` matching
For example, to get the target namespace from a ClusterRoleBinding object, the users can easily call 
`obj.Get(ns, "subjects", "kind=ServiceAccount", "namespace")`
`obj.Set(newNs, "subjects", "kind=ServiceAccount", "namespace")`
`ns := obj.GetStringOrDie("subjects", "kind=ServiceAccount", "namespace") // ns = example`
`obj.SetStringOrDie(newNs, "subjects", "kind=ServiceAccount", "namespace")`
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: read-secrets-global
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: secret-reader
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: Group 
  name: admin 
  namespace: irrelevant # not chosen
- apiGroup: rbac.authorization.k8s.io
  kind: ServiceAccount
  name: admin
  namespace: example # target namespace
```
