### PR TITLE
Improve functionRunner interface

### DIFF
--- a/go/fn/examples/data/runner-configmap-general.yaml
+++ b/go/fn/examples/data/runner-configmap-general.yaml
@@ -6,7 +6,10 @@ items:
     metadata:
       name: example
 functionConfig:
-  apiVersion: fn.kpt.dev/v1alpha1
-  kind: SetLabels
+  apiVersion: v1
+  kind: ConfigMap
   metadata:
-    name: setlabel-fn-config
+    name: runner-fn-config
+  data:
+    project-id: kpt-dev
+    managed-by: kpt

--- a/go/fn/examples/data/runner-configmap.yaml
+++ b/go/fn/examples/data/runner-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+items:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: example
+functionConfig:
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: customConfig
+  data:
+    owner: kpt
+    org: google

--- a/go/fn/examples/data/runner-customFnConfig.yaml
+++ b/go/fn/examples/data/runner-customFnConfig.yaml
@@ -1,0 +1,14 @@
+apiVersion: config.kubernetes.io/v1
+kind: ResourceList
+items:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: example
+functionConfig:
+  apiVersion: fn.kpt.dev/v1alpha1
+  kind: CustomFnConfig
+  metadata:
+    name: runner-fn-config
+  owner: kpt
+  org: google

--- a/go/fn/functionrunner.go
+++ b/go/fn/functionrunner.go
@@ -15,5 +15,5 @@
 package fn
 
 type Runner interface {
-	Run(context *Context, functionConfig *KubeObject, items []*KubeObject)
+	Run(context *Context, functionConfig *KubeObject, items KubeObjects)
 }


### PR DESCRIPTION
- Update `items` from `[]*KubeObject` to `KubeObjects`. This aligns the resourceList.items with the latest change in https://github.com/GoogleContainerTools/kpt-functions-sdk/commit/78748f08d9977e08b5cf2dd678d04ed22d209a75#diff-7b055320c11f07c233d6db3fec422e3059d52a0f295a12e02b489aa4a539a50d 
- functionRunner can parse functionConfig value for `ConfigMap.Data` and custom functionConfig in two formats

For example, a `SetLabel` struct that implements `Runner` interface, have its `Owner` and `Org` value automatically parsed from  either 1. `SetLabels` type with `owner` and `org` fields or 2. `ConfigMap` type with `Data` fields having keys `owner` and `org` 
```go
type SetLabels struct {
	Owner string
	Org   string
}
```
FunctionConfig 1
```go
apiVersion:  fn.kpt.dev/v1alpha1
kind: SetLabel
metadata:
   name: custom
owner: kpt
org: google
```
FunctionConfig 2
```go
apiVersion: v1
kind: ConfigMap
metadata:
   name: custom
data:
  owner: kpt 
  org: google
```