### PR TITLE
feat: modifying error message for subobject

### DIFF
--- a/go/fn/errors.go
+++ b/go/fn/errors.go
@@ -39,11 +39,12 @@ func (e *errKubeObjectFields) Error() string {
 
 // errSubObjectFields raises if the SubObject operation panics.
 type errSubObjectFields struct {
+	obj    *SubObject
 	fields []string
 }
 
 func (e *errSubObjectFields) Error() string {
-	return fmt.Sprintf("SubObject has unmatched field type: `%v", strings.Join(e.fields, "/"))
+	return fmt.Sprintf("SubObject has unmatched field type: `%v`, relative path to parent kubeObject(group=%v, version=%v, kind=%v) is `%v`", strings.Join(e.fields, "/"), e.obj.gvk.Group, e.obj.gvk.Version, e.obj.gvk.Kind, strings.Join(e.obj.nodePath, "/"))
 }
 
 type errResultEnd struct {

--- a/go/fn/object.go
+++ b/go/fn/object.go
@@ -540,7 +540,7 @@ func (o *KubeObject) SetHeadComment(comment string, fields ...string) error {
 // be a pointer to a typed object. It will panic if it encounters an error.
 func (o *SubObject) AsOrDie(ptr interface{}) {
 	if err := o.As(ptr); err != nil {
-		panic(errSubObjectFields{fields: nil})
+		panic(errSubObjectFields{obj: o, fields: nil})
 	}
 }
 

--- a/go/fn/object.go
+++ b/go/fn/object.go
@@ -154,14 +154,6 @@ func (o *SubObject) NestedSlice(fields ...string) (SliceSubObjects, bool, error)
 	}
 	var val []*SubObject
 	for _, obj := range objects {
-		if o.nodePath == nil {
-			oGroup, oVersion := ParseGroupVersion(o.GetString("apiVersion"))
-			val = append(val, &SubObject{obj: obj, gvk: &ResourceIdentifier{
-				Group:   oGroup,
-				Version: oVersion,
-				Kind:    o.GetString("kind"),
-			}, nodePath: append(o.nodePath, fields...)})
-		}
 		val = append(val, &SubObject{obj: obj, gvk: o.gvk, nodePath: append(o.nodePath, fields...)})
 	}
 	return val, true, nil
@@ -967,20 +959,6 @@ func (o *SubObject) GetMap(k string) *SubObject {
 	if err != nil || !found {
 		return nil
 	}
-	// this SubObject is the root kubeObject
-	if o.nodePath == nil {
-		oGroup, oVersion := ParseGroupVersion(o.GetString("apiVersion"))
-		return &SubObject{
-			obj: internal.NewMap(variant.YNode()),
-			gvk: &ResourceIdentifier{
-				Group:   oGroup,
-				Version: oVersion,
-				Kind:    o.GetString("kind"),
-			},
-			nodePath: append(o.nodePath, k),
-		}
-	}
-	// otherwise store the SubObject's relative path
 	return &SubObject{obj: internal.NewMap(variant.YNode()), gvk: o.gvk, nodePath: append(o.nodePath, k)}
 }
 

--- a/go/fn/object_test.go
+++ b/go/fn/object_test.go
@@ -61,7 +61,7 @@ spec:
 				panic(v)
 			}
 		}
-		expected := "SubObject has unmatched field type: `metadata`, relative path to parent kubeObject(group=apps, version=, kind=StatefulSet) is ``"
+		expected := "SubObject has unmatched field type: `metadata`, relative path to parent kubeObject(group=apps, version=v1, kind=StatefulSet) is ``"
 		assert.Equal(t, err.Error(), expected)
 	}()
 	_, _, err = parseInput.NestedSlice("metadata")

--- a/go/fn/resourcelist.go
+++ b/go/fn/resourcelist.go
@@ -128,7 +128,7 @@ func ParseResourceList(in []byte) (*ResourceList, error) {
 // toYNode converts the ResourceList to the yaml.Node representation.
 func (rl *ResourceList) toYNode() (*yaml.Node, error) {
 	reMap := internal.NewMap(nil)
-	reObj := &KubeObject{SubObject{reMap}}
+	reObj := &KubeObject{SubObject: SubObject{obj: reMap}}
 	reObj.SetAPIVersion(kio.ResourceListAPIVersion)
 	reObj.SetKind(kio.ResourceListKind)
 


### PR DESCRIPTION
Current subobject does not give information about where the error was. When a file contains multiple resources, it is difficult to see where the error is. By adding GVK and relative path to KubeObject, it would be much easier to see what went wrong