### PR TITLE
Add versioning reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ See [Interfaces](docs/interfaces.md) for details and code examples.
 - [Testing](docs/testing.md) — golden test patterns
 - [Containerizing](docs/containerizing.md) — building and running function images
 
+## Versioning
+
+This project follows the [kpt project versioning guidelines](https://github.com/kptdev/governance/blob/main/VERSIONING.md).
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on DCO sign-off, copyright headers, and code review process.


### PR DESCRIPTION
 ## Description

  - **What changed:** Added a Versioning section to `README.md` linking to the governance versioning guidelines
  - **Why it's needed:** The SDK repo had no versioning documentation; all kptdev repos should reference the shared strategy
  - **How it works:** Single section with a link to `kptdev/governance/VERSIONING.md`

  ## Related Issue(s)

  - Relates to kptdev/kpt#4621

  ## Type of Change

  - [x] Documentation

  ## Checklist

  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**
  
  If so, please describe how:
    - Kiro to verify the change and prepare the PR description